### PR TITLE
Refactor gastos page to use Firestore

### DIFF
--- a/lib/model/gasto.dart
+++ b/lib/model/gasto.dart
@@ -44,4 +44,28 @@ class Gasto {
         'estado': estado,
         'idUsuario': idUsuario,
       };
+
+  Gasto copyWith({
+    String? id,
+    String? descripcion,
+    String? idCategoria,
+    double? monto,
+    DateTime? fechaVencimiento,
+    DateTime? fechaCreacion,
+    String? detalles,
+    bool? estado,
+    String? idUsuario,
+  }) {
+    return Gasto(
+      id: id ?? this.id,
+      descripcion: descripcion ?? this.descripcion,
+      idCategoria: idCategoria ?? this.idCategoria,
+      monto: monto ?? this.monto,
+      fechaVencimiento: fechaVencimiento ?? this.fechaVencimiento,
+      fechaCreacion: fechaCreacion ?? this.fechaCreacion,
+      detalles: detalles ?? this.detalles,
+      estado: estado ?? this.estado,
+      idUsuario: idUsuario ?? this.idUsuario,
+    );
+  }
 }

--- a/lib/services/categoria_service_firebase.dart
+++ b/lib/services/categoria_service_firebase.dart
@@ -1,46 +1,48 @@
-// import 'package:cloud_firestore/cloud_firestore.dart';
-// import 'package:firebase_auth/firebase_auth.dart';
-// import '../model/categoria.dart';
-// import 'package:uuid/uuid.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
-// class CategoriaServiceFirebase {
-//   final _firestore = FirebaseFirestore.instance;
-//   final _uid = FirebaseAuth.instance.currentUser!.uid;
+import '../model/categoria.dart';
 
-//   Future<List<Categoria>> obtenerTodas() async {
-//     final snapshot = await _firestore
-//         .collection('categorias')
-//         .doc(_uid)
-//         .collection('items')
-//         .get();
+class CategoriaServiceFirebase {
+  final _firestore = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
 
-//     return snapshot.docs.map((e) => Categoria.fromMap(e.data())).toList();
-//   }
+  String get _uid => _auth.currentUser!.uid;
 
-//   Future<void> crear(Categoria categoria) async {
-//     await _firestore
-//         .collection('categorias')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(categoria.id)
-//         .set(categoria.toMap());
-//   }
+  Future<List<Categoria>> obtenerTodas() async {
+    final snapshot = await _firestore
+        .collection('categorias')
+        .doc(_uid)
+        .collection('items')
+        .get();
 
-//   Future<void> actualizar(Categoria categoria) async {
-//     await _firestore
-//         .collection('categorias')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(categoria.id)
-//         .update(categoria.toMap());
-//   }
+    return snapshot.docs.map((e) => Categoria.fromMap(e.data())).toList();
+  }
 
-//   Future<void> eliminar(String id) async {
-//     await _firestore
-//         .collection('categorias')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(id)
-//         .delete();
-//   }
-// }
+  Future<void> crear(Categoria categoria) async {
+    await _firestore
+        .collection('categorias')
+        .doc(_uid)
+        .collection('items')
+        .doc(categoria.id)
+        .set(categoria.toMap());
+  }
+
+  Future<void> actualizar(Categoria categoria) async {
+    await _firestore
+        .collection('categorias')
+        .doc(_uid)
+        .collection('items')
+        .doc(categoria.id)
+        .update(categoria.toMap());
+  }
+
+  Future<void> eliminar(String id) async {
+    await _firestore
+        .collection('categorias')
+        .doc(_uid)
+        .collection('items')
+        .doc(id)
+        .delete();
+  }
+}

--- a/lib/services/gasto_service_firebase.dart
+++ b/lib/services/gasto_service_firebase.dart
@@ -1,45 +1,48 @@
-// import 'package:cloud_firestore/cloud_firestore.dart';
-// import 'package:firebase_auth/firebase_auth.dart';
-// import '../model/gasto.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
-// class GastoServiceFirebase {
-//   final _firestore = FirebaseFirestore.instance;
-//   final _uid = FirebaseAuth.instance.currentUser!.uid;
+import '../model/gasto.dart';
 
-//   Future<List<Gasto>> obtenerTodos() async {
-//     final snapshot = await _firestore
-//         .collection('gastos')
-//         .doc(_uid)
-//         .collection('items')
-//         .get();
+class GastoServiceFirebase {
+  final _firestore = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
 
-//     return snapshot.docs.map((e) => Gasto.fromMap(e.data())).toList();
-//   }
+  String get _uid => _auth.currentUser!.uid;
 
-//   Future<void> crear(Gasto gasto) async {
-//     await _firestore
-//         .collection('gastos')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(gasto.id)
-//         .set(gasto.toMap());
-//   }
+  Future<List<Gasto>> obtenerTodos() async {
+    final snapshot = await _firestore
+        .collection('gastos')
+        .doc(_uid)
+        .collection('items')
+        .get();
 
-//   Future<void> actualizar(Gasto gasto) async {
-//     await _firestore
-//         .collection('gastos')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(gasto.id)
-//         .update(gasto.toMap());
-//   }
+    return snapshot.docs.map((e) => Gasto.fromMap(e.data())).toList();
+  }
 
-//   Future<void> eliminar(String id) async {
-//     await _firestore
-//         .collection('gastos')
-//         .doc(_uid)
-//         .collection('items')
-//         .doc(id)
-//         .delete();
-//   }
-// }
+  Future<void> crear(Gasto gasto) async {
+    await _firestore
+        .collection('gastos')
+        .doc(_uid)
+        .collection('items')
+        .doc(gasto.id)
+        .set(gasto.toMap());
+  }
+
+  Future<void> actualizar(Gasto gasto) async {
+    await _firestore
+        .collection('gastos')
+        .doc(_uid)
+        .collection('items')
+        .doc(gasto.id)
+        .update(gasto.toMap());
+  }
+
+  Future<void> eliminar(String id) async {
+    await _firestore
+        .collection('gastos')
+        .doc(_uid)
+        .collection('items')
+        .doc(id)
+        .delete();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,10 +42,9 @@ dependencies:
   month_picker_dialog: ^6.2.1
   fl_chart: ^0.63.0
   timezone: ^0.9.2
-  # firebase_core: ^2.24.2
-  # firebase_auth: 4.16.0
-  # firebase_database: ^10.4.5
-  # cloud_firestore: ^4.15.6
+  firebase_core: ^2.24.2
+  firebase_auth: 4.16.0
+  cloud_firestore: ^4.15.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In Android, build-name is used as versionName while build-number used as versionCode.
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+# Read more about iOS versioning at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1


### PR DESCRIPTION
## Summary
- Replace Hive-based services with Firebase versions for gastos and categorias
- Query Firestore for user gastos with month, category, and state filters
- Update gasto actions to create, update, and delete Firestore documents
- Display gastos via a StreamBuilder for live updates

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c194493c5c8332a701bb9bf3e53751