### PR TITLE
feat: add third-party expenses management module

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,32 +2,79 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:provider/provider.dart';
 import 'package:tubilletera/model/categoria_hive.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/cuota_terceros.dart';
 import 'package:tubilletera/model/gasto_hive.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
 import 'package:tubilletera/pages/Bienvenida/bienvenida_page.dart';
 import 'package:tubilletera/pages/Categorias/categorias_page.dart';
 import 'package:tubilletera/pages/Configuraciones/configuraciones_page.dart';
 import 'package:tubilletera/pages/Gastos/gastos_page.dart';
+import 'package:tubilletera/pages/GastosTerceros/gastos_terceros_page.dart';
 import 'package:tubilletera/pages/Home/home_page.dart';
 import 'package:tubilletera/pages/IniciarSesion/iniciar_sesion_page.dart';
 import 'package:tubilletera/pages/Registrarse/registrarse_page.dart';
 import 'package:tubilletera/pages/Splash/splash_page.dart';
+import 'package:tubilletera/providers/third_party_expenses_provider.dart';
+import 'package:tubilletera/services/third_party_expense_service.dart';
+import 'package:tubilletera/services/third_party_person_service.dart';
 import 'package:tubilletera/theme/app_theme.dart';
 
-void main() async {  
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Hive.initFlutter();
   await Hive.openBox('usersBox');
 
-  Hive.registerAdapter(CategoriaAdapter());
-  await Hive.openBox<Categoria>('categoriasBox');
+  _registerAdapters();
 
-  Hive.registerAdapter(GastoAdapter());
+  await Hive.openBox<Categoria>('categoriasBox');
   await Hive.openBox<Gasto>('gastoBox');
+  await Hive.openBox<PersonaTercero>(ThirdPartyPersonService.boxName);
+  await Hive.openBox<GastoTercero>(ThirdPartyExpenseService.boxName);
 
   await initializeDateFormatting('es', 'AR');
-  runApp(const MyApp());
+  runApp(const _AppProviders());
+}
+
+void _registerAdapters() {
+  try {
+    Hive.registerAdapter(CategoriaAdapter());
+  } catch (_) {}
+  try {
+    Hive.registerAdapter(GastoAdapter());
+  } catch (_) {}
+  try {
+    Hive.registerAdapter(CuotaEstadoAdapter());
+  } catch (_) {}
+  try {
+    Hive.registerAdapter(CuotaTerceroAdapter());
+  } catch (_) {}
+  try {
+    Hive.registerAdapter(PersonaTerceroAdapter());
+  } catch (_) {}
+  try {
+    Hive.registerAdapter(GastoTerceroAdapter());
+  } catch (_) {}
+}
+
+class _AppProviders extends StatelessWidget {
+  const _AppProviders();
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => ThirdPartyExpensesProvider()..cargarDatos(),
+        ),
+      ],
+      child: const MyApp(),
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -36,29 +83,30 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      locale: const Locale('es','AR'),
+      locale: const Locale('es', 'AR'),
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [
-        Locale('es', 'AR'), // Español (Argentina)
-        Locale('en', 'US'), // Inglés
+        Locale('es', 'AR'),
+        Locale('en', 'US'),
       ],
       title: 'Login Demo',
       theme: AppTheme.light,
       initialRoute: '/splash',
-        routes: {
-          '/': (context) => const BienvenidaPage(),
-          '/splash': (context) => const SplashPage(),
-          '/login': (context) => const IniciarSesionPage(),
-          '/register': (context) => const RegistrarsePage(),
-          '/home': (context) => const HomePage(),
-          '/gastos': (context) => const GastosPage(),
-          '/categorias': (context) => const CategoriasPage(),
-          '/configuraciones': (context) => const ConfiguracionesPage(),
-        },
+      routes: {
+        '/': (context) => const BienvenidaPage(),
+        '/splash': (context) => const SplashPage(),
+        '/login': (context) => const IniciarSesionPage(),
+        '/register': (context) => const RegistrarsePage(),
+        '/home': (context) => const HomePage(),
+        '/gastos': (context) => const GastosPage(),
+        '/gastos-terceros': (context) => const GastosTercerosPage(),
+        '/categorias': (context) => const CategoriasPage(),
+        '/configuraciones': (context) => const ConfiguracionesPage(),
+      },
     );
   }
 }

--- a/lib/main_drawer.dart
+++ b/lib/main_drawer.dart
@@ -24,6 +24,7 @@ class MainDrawer extends StatelessWidget {
             // Parte superior del menú
             _buildItem(context, Icons.home, 'Inicio', '/home'),
             _buildItem(context, Icons.list, 'Gastos', '/gastos'),
+            _buildItem(context, Icons.groups, 'Gastos de terceros', '/gastos-terceros'),
             _buildItem(context, Icons.category, 'Categorías', '/categorias'),
 
             const Spacer(), // empuja lo de abajo

--- a/lib/model/cuota_estado.dart
+++ b/lib/model/cuota_estado.dart
@@ -1,0 +1,12 @@
+import 'package:hive/hive.dart';
+
+part 'cuota_estado.g.dart';
+
+@HiveType(typeId: 10)
+enum CuotaEstado {
+  @HiveField(0)
+  pendiente,
+
+  @HiveField(1)
+  pagada,
+}

--- a/lib/model/cuota_estado.g.dart
+++ b/lib/model/cuota_estado.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cuota_estado.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class CuotaEstadoAdapter extends TypeAdapter<CuotaEstado> {
+  @override
+  final int typeId = 10;
+
+  @override
+  CuotaEstado read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return CuotaEstado.pendiente;
+      case 1:
+        return CuotaEstado.pagada;
+      default:
+        return CuotaEstado.pendiente;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, CuotaEstado obj) {
+    switch (obj) {
+      case CuotaEstado.pendiente:
+        writer.writeByte(0);
+        break;
+      case CuotaEstado.pagada:
+        writer.writeByte(1);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CuotaEstadoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/model/cuota_terceros.dart
+++ b/lib/model/cuota_terceros.dart
@@ -1,0 +1,30 @@
+import 'package:hive/hive.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+
+part 'cuota_terceros.g.dart';
+
+@HiveType(typeId: 11)
+class CuotaTercero extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  double monto;
+
+  @HiveField(2)
+  DateTime fechaVencimiento;
+
+  @HiveField(3)
+  CuotaEstado estado;
+
+  CuotaTercero({
+    required this.id,
+    required this.monto,
+    required this.fechaVencimiento,
+    this.estado = CuotaEstado.pendiente,
+  });
+
+  bool get estaVencida =>
+      estado == CuotaEstado.pendiente &&
+      fechaVencimiento.isBefore(DateTime.now());
+}

--- a/lib/model/cuota_terceros.g.dart
+++ b/lib/model/cuota_terceros.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cuota_terceros.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class CuotaTerceroAdapter extends TypeAdapter<CuotaTercero> {
+  @override
+  final int typeId = 11;
+
+  @override
+  CuotaTercero read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return CuotaTercero(
+      id: fields[0] as String,
+      monto: fields[1] as double,
+      fechaVencimiento: fields[2] as DateTime,
+      estado: fields[3] as CuotaEstado,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CuotaTercero obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.monto)
+      ..writeByte(2)
+      ..write(obj.fechaVencimiento)
+      ..writeByte(3)
+      ..write(obj.estado);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CuotaTerceroAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/model/gasto_terceros.dart
+++ b/lib/model/gasto_terceros.dart
@@ -1,0 +1,44 @@
+import 'package:hive/hive.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/cuota_terceros.dart';
+
+part 'gasto_terceros.g.dart';
+
+@HiveType(typeId: 13)
+class GastoTercero extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String personaId;
+
+  @HiveField(2)
+  double montoTotal;
+
+  @HiveField(3)
+  int cantidadCuotas;
+
+  @HiveField(4)
+  DateTime fechaPrimerVencimiento;
+
+  @HiveField(5)
+  List<CuotaTercero> cuotas;
+
+  GastoTercero({
+    required this.id,
+    required this.personaId,
+    required this.montoTotal,
+    required this.cantidadCuotas,
+    required this.fechaPrimerVencimiento,
+    required this.cuotas,
+  });
+
+  double get totalPagado =>
+      cuotas.where((c) => c.estado == CuotaEstado.pagada).fold(0, (sum, cuota) => sum + cuota.monto);
+
+  double get totalPendiente =>
+      cuotas.where((c) => c.estado != CuotaEstado.pagada).fold(0, (sum, cuota) => sum + cuota.monto);
+
+  double get totalAdeudado =>
+      cuotas.fold(0, (sum, cuota) => sum + cuota.monto);
+}

--- a/lib/model/gasto_terceros.g.dart
+++ b/lib/model/gasto_terceros.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gasto_terceros.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class GastoTerceroAdapter extends TypeAdapter<GastoTercero> {
+  @override
+  final int typeId = 13;
+
+  @override
+  GastoTercero read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return GastoTercero(
+      id: fields[0] as String,
+      personaId: fields[1] as String,
+      montoTotal: fields[2] as double,
+      cantidadCuotas: fields[3] as int,
+      fechaPrimerVencimiento: fields[4] as DateTime,
+      cuotas: (fields[5] as List).cast<CuotaTercero>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, GastoTercero obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.personaId)
+      ..writeByte(2)
+      ..write(obj.montoTotal)
+      ..writeByte(3)
+      ..write(obj.cantidadCuotas)
+      ..writeByte(4)
+      ..write(obj.fechaPrimerVencimiento)
+      ..writeByte(5)
+      ..write(obj.cuotas);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GastoTerceroAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/model/persona_terceros.dart
+++ b/lib/model/persona_terceros.dart
@@ -1,0 +1,27 @@
+import 'package:hive/hive.dart';
+
+part 'persona_terceros.g.dart';
+
+@HiveType(typeId: 12)
+class PersonaTercero extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String nombre;
+
+  @HiveField(2)
+  String apellido;
+
+  @HiveField(3)
+  String? email;
+
+  PersonaTercero({
+    required this.id,
+    required this.nombre,
+    required this.apellido,
+    this.email,
+  });
+
+  String get nombreCompleto => '$nombre $apellido'.trim();
+}

--- a/lib/model/persona_terceros.g.dart
+++ b/lib/model/persona_terceros.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'persona_terceros.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class PersonaTerceroAdapter extends TypeAdapter<PersonaTercero> {
+  @override
+  final int typeId = 12;
+
+  @override
+  PersonaTercero read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PersonaTercero(
+      id: fields[0] as String,
+      nombre: fields[1] as String,
+      apellido: fields[2] as String,
+      email: fields[3] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, PersonaTercero obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.nombre)
+      ..writeByte(2)
+      ..write(obj.apellido)
+      ..writeByte(3)
+      ..write(obj.email);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PersonaTerceroAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/pages/GastosTerceros/gasto_tercero_form_page.dart
+++ b/lib/pages/GastosTerceros/gasto_tercero_form_page.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/pages/GastosTerceros/persona_tercero_form_page.dart';
+import 'package:tubilletera/providers/third_party_expenses_provider.dart';
+
+class GastoTerceroFormPage extends StatefulWidget {
+  const GastoTerceroFormPage({
+    super.key,
+    this.personaPreseleccionada,
+    this.gasto,
+  });
+
+  final PersonaTercero? personaPreseleccionada;
+  final GastoTercero? gasto;
+
+  @override
+  State<GastoTerceroFormPage> createState() => _GastoTerceroFormPageState();
+}
+
+class _GastoTerceroFormPageState extends State<GastoTerceroFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _montoTotalController;
+  late final TextEditingController _montoCuotaController;
+  late final TextEditingController _cantidadCuotasController;
+  DateTime? _fechaVencimiento;
+  int _modo = 0; // 0 = total, 1 = monto por cuota
+  String? _personaId;
+
+  @override
+  void initState() {
+    super.initState();
+    final gasto = widget.gasto;
+    _montoTotalController = TextEditingController(
+      text: gasto != null ? gasto.montoTotal.toStringAsFixed(2) : '',
+    );
+    _montoCuotaController = TextEditingController(
+      text: gasto != null && gasto.cuotas.isNotEmpty
+          ? gasto.cuotas.first.monto.toStringAsFixed(2)
+          : '',
+    );
+    _cantidadCuotasController = TextEditingController(
+      text: gasto != null ? gasto.cantidadCuotas.toString() : '',
+    );
+    _fechaVencimiento = gasto?.fechaPrimerVencimiento;
+    _personaId = gasto?.personaId ?? widget.personaPreseleccionada?.id;
+  }
+
+  @override
+  void dispose() {
+    _montoTotalController.dispose();
+    _montoCuotaController.dispose();
+    _cantidadCuotasController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ThirdPartyExpensesProvider>();
+    final personas = provider.personas;
+    final moneda = NumberFormat.currency(locale: 'es_AR', symbol: '\$');
+    final fechaTexto = _fechaVencimiento == null
+        ? 'Seleccionar fecha'
+        : DateFormat('dd/MM/yyyy').format(_fechaVencimiento!);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.gasto == null ? 'Nuevo gasto' : 'Editar gasto'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              DropdownButtonFormField<String>(
+                value: _personaId,
+                decoration: const InputDecoration(labelText: 'Persona'),
+                items: personas
+                    .map(
+                      (persona) => DropdownMenuItem(
+                        value: persona.id,
+                        child: Text(persona.nombreCompleto),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) => setState(() => _personaId = value),
+                validator: (value) => value == null ? 'Seleccione una persona' : null,
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: () async {
+                    await Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const PersonaTerceroFormPage(),
+                      ),
+                    );
+                    if (mounted) {
+                      context.read<ThirdPartyExpensesProvider>().cargarDatos();
+                      setState(() {});
+                    }
+                  },
+                  icon: const Icon(Icons.person_add_alt),
+                  label: const Text('Nueva persona'),
+                ),
+              ),
+              const SizedBox(height: 12),
+              ToggleButtons(
+                isSelected: [_modo == 0, _modo == 1],
+                onPressed: (index) => setState(() => _modo = index),
+                borderRadius: BorderRadius.circular(8),
+                children: const [
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: Text('Monto total'),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: Text('Monto por cuota'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              if (_modo == 0)
+                TextFormField(
+                  controller: _montoTotalController,
+                  decoration: InputDecoration(labelText: 'Monto total (${moneda.currencySymbol})'),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                  validator: _validarMonto,
+                )
+              else
+                TextFormField(
+                  controller: _montoCuotaController,
+                  decoration: InputDecoration(labelText: 'Monto por cuota (${moneda.currencySymbol})'),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                  validator: _validarMonto,
+                ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _cantidadCuotasController,
+                decoration: const InputDecoration(labelText: 'Cantidad de cuotas'),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Ingrese la cantidad de cuotas';
+                  }
+                  final numero = int.tryParse(value);
+                  if (numero == null || numero <= 0) {
+                    return 'La cantidad debe ser mayor a cero';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Fecha primer vencimiento'),
+                subtitle: Text(fechaTexto),
+                trailing: const Icon(Icons.calendar_today),
+                onTap: _seleccionarFecha,
+              ),
+              const SizedBox(height: 16),
+              if (_modo == 0 && _cantidadCuotasController.text.isNotEmpty && _montoTotalController.text.isNotEmpty)
+                Text(
+                  'Monto por cuota estimado: ${_calcularMontoCuotaDesdeTotal(moneda)}',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              if (_modo == 1 && _cantidadCuotasController.text.isNotEmpty && _montoCuotaController.text.isNotEmpty)
+                Text(
+                  'Monto total estimado: ${_calcularTotalDesdeCuota(moneda)}',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: _guardar,
+                icon: const Icon(Icons.save),
+                label: const Text('Guardar gasto'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _validarMonto(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Ingrese un monto válido';
+    }
+    final monto = double.tryParse(value.replaceAll(',', '.'));
+    if (monto == null || monto <= 0) {
+      return 'El monto debe ser mayor a cero';
+    }
+    return null;
+  }
+
+  Future<void> _seleccionarFecha() async {
+    final ahora = DateTime.now();
+    final seleccionada = await showDatePicker(
+      context: context,
+      initialDate: _fechaVencimiento ?? ahora,
+      firstDate: DateTime(ahora.year - 1),
+      lastDate: DateTime(ahora.year + 5),
+    );
+    if (seleccionada != null) {
+      setState(() => _fechaVencimiento = seleccionada);
+    }
+  }
+
+  String _calcularMontoCuotaDesdeTotal(NumberFormat moneda) {
+    final total = double.tryParse(_montoTotalController.text.replaceAll(',', '.')) ?? 0;
+    final cuotas = int.tryParse(_cantidadCuotasController.text) ?? 1;
+    if (cuotas == 0) return moneda.format(0);
+    return moneda.format(total / cuotas);
+  }
+
+  String _calcularTotalDesdeCuota(NumberFormat moneda) {
+    final cuota = double.tryParse(_montoCuotaController.text.replaceAll(',', '.')) ?? 0;
+    final cuotas = int.tryParse(_cantidadCuotasController.text) ?? 1;
+    return moneda.format(cuota * cuotas);
+  }
+
+  Future<void> _guardar() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    if (_fechaVencimiento == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Seleccione la fecha del primer vencimiento')),
+      );
+      return;
+    }
+    final provider = context.read<ThirdPartyExpensesProvider>();
+    final cuotas = int.parse(_cantidadCuotasController.text);
+    final personaId = _personaId;
+    if (personaId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Debe seleccionar una persona')),
+      );
+      return;
+    }
+
+    double montoTotal;
+    double? montoPorCuota;
+    if (_modo == 0) {
+      montoTotal = double.parse(_montoTotalController.text.replaceAll(',', '.'));
+      montoPorCuota = null;
+    } else {
+      montoPorCuota = double.parse(_montoCuotaController.text.replaceAll(',', '.'));
+      montoTotal = montoPorCuota * cuotas;
+    }
+
+    try {
+      await provider.registrarGasto(
+        id: widget.gasto?.id,
+        personaId: personaId,
+        montoTotal: montoTotal,
+        cantidadCuotas: cuotas,
+        fechaPrimerVencimiento: _fechaVencimiento!,
+        montoPorCuota: montoPorCuota,
+      );
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No se pudo guardar el gasto: ${e.toString()}')),
+      );
+    }
+  }
+}

--- a/lib/pages/GastosTerceros/gastos_terceros_page.dart
+++ b/lib/pages/GastosTerceros/gastos_terceros_page.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:tubilletera/main_drawer.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/pages/GastosTerceros/gasto_tercero_form_page.dart';
+import 'package:tubilletera/pages/GastosTerceros/persona_tercero_form_page.dart';
+import 'package:tubilletera/pages/GastosTerceros/widgets/gasto_tercero_card.dart';
+import 'package:tubilletera/providers/third_party_expenses_provider.dart';
+
+class GastosTercerosPage extends StatefulWidget {
+  const GastosTercerosPage({super.key});
+
+  @override
+  State<GastosTercerosPage> createState() => _GastosTercerosPageState();
+}
+
+class _GastosTercerosPageState extends State<GastosTercerosPage> {
+  bool _exportando = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ThirdPartyExpensesProvider>();
+    final personas = provider.personas;
+    final moneda = NumberFormat.currency(locale: 'es_AR', symbol: '\$');
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gastos de Terceros'),
+        actions: [
+          IconButton(
+            onPressed: _exportando ? null : () => _generarReporte(provider),
+            icon: _exportando
+                ? const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.picture_as_pdf_outlined),
+            tooltip: 'Generar reporte PDF',
+          ),
+          IconButton(
+            onPressed: () => _abrirFormularioPersona(),
+            icon: const Icon(Icons.person_add_alt_1),
+            tooltip: 'Agregar persona',
+          ),
+        ],
+      ),
+      drawer: MainDrawer(currentRoute: '/gastos-terceros'),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _abrirFormularioGasto(),
+        icon: const Icon(Icons.add),
+        label: const Text('Nuevo gasto'),
+      ),
+      body: personas.isEmpty
+          ? const Center(
+              child: Text('No hay personas cargadas. Agregá una para registrar gastos.'),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: personas.length,
+              itemBuilder: (context, index) {
+                final persona = personas[index];
+                final gastos = provider.gastosPorPersona(persona.id);
+                final totalAdeudado = provider.totalAdeudadoPersona(persona.id);
+                final totalPagado = provider.totalPagadoPersona(persona.id);
+                final totalPendiente = provider.totalPendientePersona(persona.id);
+
+                return Card(
+                  margin: const EdgeInsets.only(bottom: 16),
+                  child: ExpansionTile(
+                    title: Text(persona.nombreCompleto),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (persona.email != null) Text(persona.email!),
+                        Text('Total adeudado: ${moneda.format(totalAdeudado)}'),
+                        Text('Pagado: ${moneda.format(totalPagado)} · Pendiente: ${moneda.format(totalPendiente)}'),
+                      ],
+                    ),
+                    trailing: PopupMenuButton<String>(
+                      onSelected: (value) {
+                        if (value == 'edit') {
+                          _abrirFormularioPersona(persona: persona);
+                        } else if (value == 'delete') {
+                          _confirmarEliminarPersona(persona);
+                        } else if (value == 'add-expense') {
+                          _abrirFormularioGasto(persona: persona);
+                        }
+                      },
+                      itemBuilder: (context) => const [
+                        PopupMenuItem(value: 'add-expense', child: Text('Nuevo gasto')),
+                        PopupMenuItem(value: 'edit', child: Text('Editar persona')),
+                        PopupMenuItem(value: 'delete', child: Text('Eliminar persona')),
+                      ],
+                    ),
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: ElevatedButton.icon(
+                            onPressed: () => _abrirFormularioGasto(persona: persona),
+                            icon: const Icon(Icons.add),
+                            label: const Text('Registrar gasto'),
+                          ),
+                        ),
+                      ),
+                      if (gastos.isEmpty)
+                        const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Text('Sin gastos registrados para esta persona.'),
+                        )
+                      else
+                        ...gastos.map(
+                          (gasto) => GastoTerceroCard(
+                            gasto: gasto,
+                            onEditar: () => _abrirFormularioGasto(persona: persona, gasto: gasto),
+                            onEliminar: () => _confirmarEliminarGasto(gasto),
+                            onToggleCuota: (cuotaId, pagada) =>
+                                provider.marcarCuota(gasto.id, cuotaId, pagada),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+
+  Future<void> _abrirFormularioPersona({PersonaTercero? persona}) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PersonaTerceroFormPage(persona: persona),
+      ),
+    );
+    if (mounted) {
+      context.read<ThirdPartyExpensesProvider>().cargarDatos();
+    }
+  }
+
+  Future<void> _abrirFormularioGasto({PersonaTercero? persona, GastoTercero? gasto}) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => GastoTerceroFormPage(
+          personaPreseleccionada: persona,
+          gasto: gasto,
+        ),
+      ),
+    );
+    if (mounted) {
+      context.read<ThirdPartyExpensesProvider>().cargarDatos();
+    }
+  }
+
+  Future<void> _confirmarEliminarPersona(PersonaTercero persona) async {
+    final provider = context.read<ThirdPartyExpensesProvider>();
+    final gastosAsociados = provider.gastosPorPersona(persona.id);
+    final eliminar = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Eliminar persona'),
+        content: Text(
+          gastosAsociados.isEmpty
+              ? '¿Desea eliminar a ${persona.nombreCompleto}?'
+              : 'La persona tiene ${gastosAsociados.length} gastos asociados. ¿Desea eliminarlos también?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Eliminar'),
+          ),
+        ],
+      ),
+    );
+
+    if (eliminar == true) {
+      await provider.eliminarPersona(persona, eliminarGastos: gastosAsociados.isNotEmpty);
+    }
+  }
+
+  Future<void> _confirmarEliminarGasto(GastoTercero gasto) async {
+    final provider = context.read<ThirdPartyExpensesProvider>();
+    final confirmar = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Eliminar gasto'),
+        content: const Text('¿Desea eliminar este gasto y sus cuotas asociadas?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Eliminar'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmar == true) {
+      await provider.eliminarGasto(gasto.id);
+    }
+  }
+
+  Future<void> _generarReporte(ThirdPartyExpensesProvider provider) async {
+    setState(() => _exportando = true);
+    try {
+      final resultado = await provider.generarReportePdf();
+      final archivo = resultado['file'] as File;
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Reporte guardado en ${archivo.path}'),
+          action: SnackBarAction(
+            label: 'Compartir',
+            onPressed: () => provider.compartirReporte(archivo),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al generar el reporte: ${e.toString()}')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _exportando = false);
+      }
+    }
+  }
+}

--- a/lib/pages/GastosTerceros/persona_tercero_form_page.dart
+++ b/lib/pages/GastosTerceros/persona_tercero_form_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/providers/third_party_expenses_provider.dart';
+
+class PersonaTerceroFormPage extends StatefulWidget {
+  const PersonaTerceroFormPage({super.key, this.persona});
+
+  final PersonaTercero? persona;
+
+  @override
+  State<PersonaTerceroFormPage> createState() => _PersonaTerceroFormPageState();
+}
+
+class _PersonaTerceroFormPageState extends State<PersonaTerceroFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nombreController;
+  late final TextEditingController _apellidoController;
+  late final TextEditingController _emailController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nombreController = TextEditingController(text: widget.persona?.nombre);
+    _apellidoController = TextEditingController(text: widget.persona?.apellido);
+    _emailController = TextEditingController(text: widget.persona?.email ?? '');
+  }
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _apellidoController.dispose();
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.persona == null ? 'Nueva persona' : 'Editar persona'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nombreController,
+                decoration: const InputDecoration(labelText: 'Nombre'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Ingrese un nombre';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _apellidoController,
+                decoration: const InputDecoration(labelText: 'Apellido'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Ingrese un apellido';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email (opcional)'),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return null;
+                  }
+                  final emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+                  if (!emailRegex.hasMatch(value.trim())) {
+                    return 'Ingrese un email válido';
+                  }
+                  return null;
+                },
+              ),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _guardar,
+                  child: const Text('Guardar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _guardar() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final provider = context.read<ThirdPartyExpensesProvider>();
+    await provider.guardarPersona(
+      id: widget.persona?.id,
+      nombre: _nombreController.text.trim(),
+      apellido: _apellidoController.text.trim(),
+      email: _emailController.text.trim(),
+    );
+    if (mounted) Navigator.of(context).pop();
+  }
+}

--- a/lib/pages/GastosTerceros/widgets/gasto_tercero_card.dart
+++ b/lib/pages/GastosTerceros/widgets/gasto_tercero_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+
+class GastoTerceroCard extends StatelessWidget {
+  const GastoTerceroCard({
+    super.key,
+    required this.gasto,
+    required this.onEditar,
+    required this.onEliminar,
+    required this.onToggleCuota,
+  });
+
+  final GastoTercero gasto;
+  final VoidCallback onEditar;
+  final VoidCallback onEliminar;
+  final void Function(String cuotaId, bool pagada) onToggleCuota;
+
+  @override
+  Widget build(BuildContext context) {
+    final currency = NumberFormat.currency(locale: 'es_AR', symbol: '\$');
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Monto total: ${currency.format(gasto.montoTotal)}',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 4),
+                      Text('Cuotas: ${gasto.cantidadCuotas}'),
+                      Text('Pagado: ${currency.format(gasto.totalPagado)}'),
+                      Text('Pendiente: ${currency.format(gasto.totalPendiente)}'),
+                    ],
+                  ),
+                ),
+                PopupMenuButton<String>(
+                  onSelected: (value) {
+                    if (value == 'edit') {
+                      onEditar();
+                    } else if (value == 'delete') {
+                      onEliminar();
+                    }
+                  },
+                  itemBuilder: (context) => const [
+                    PopupMenuItem(value: 'edit', child: Text('Editar')),
+                    PopupMenuItem(value: 'delete', child: Text('Eliminar')),
+                  ],
+                ),
+              ],
+            ),
+            const Divider(),
+            Column(
+              children: gasto.cuotas.asMap().entries.map((entry) {
+                final index = entry.key + 1;
+                final cuota = entry.value;
+                final fecha = cuota.fechaVencimiento;
+                final fechaTexto = DateFormat('dd/MM/yyyy').format(fecha);
+                final estadoTexto = cuota.estado == CuotaEstado.pagada
+                    ? 'Pagada'
+                    : cuota.estaVencida
+                        ? 'Vencida'
+                        : 'Pendiente';
+                return CheckboxListTile(
+                  value: cuota.estado == CuotaEstado.pagada,
+                  onChanged: (value) => onToggleCuota(cuota.id, value ?? false),
+                  title: Text('Cuota $index - ${currency.format(cuota.monto)}'),
+                  subtitle: Text('Vence $fechaTexto · Estado: $estadoTexto'),
+                  controlAffinity: ListTileControlAffinity.leading,
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/third_party_expenses_provider.dart
+++ b/lib/providers/third_party_expenses_provider.dart
@@ -1,0 +1,166 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/services/third_party_expense_calculator.dart';
+import 'package:tubilletera/services/third_party_expense_service.dart';
+import 'package:tubilletera/services/third_party_person_service.dart';
+import 'package:tubilletera/services/third_party_pdf_service.dart';
+
+class ThirdPartyExpensesProvider extends ChangeNotifier {
+  ThirdPartyExpensesProvider({
+    ThirdPartyPersonService? personService,
+    ThirdPartyExpenseService? expenseService,
+    ThirdPartyPdfService? pdfService,
+  })  : _personService = personService ?? ThirdPartyPersonService(),
+        _expenseService = expenseService ?? ThirdPartyExpenseService(),
+        _pdfService = pdfService ?? ThirdPartyPdfService();
+
+  final ThirdPartyPersonService _personService;
+  final ThirdPartyExpenseService _expenseService;
+  final ThirdPartyPdfService _pdfService;
+  final _uuid = const Uuid();
+
+  final List<PersonaTercero> _personas = [];
+  final List<GastoTercero> _gastos = [];
+
+  UnmodifiableListView<PersonaTercero> get personas => UnmodifiableListView(_personas);
+
+  void cargarDatos() {
+    _personas
+      ..clear()
+      ..addAll(_personService.obtenerPersonas());
+    _gastos
+      ..clear()
+      ..addAll(_expenseService.obtenerGastos());
+    notifyListeners();
+  }
+
+  List<GastoTercero> gastosPorPersona(String personaId) {
+    return _gastos.where((gasto) => gasto.personaId == personaId).toList()
+      ..sort((a, b) => a.fechaPrimerVencimiento.compareTo(b.fechaPrimerVencimiento));
+  }
+
+  double totalAdeudadoPersona(String personaId) {
+    return ThirdPartyExpenseCalculator.totalAdeudadoPorPersona(gastosPorPersona(personaId));
+  }
+
+  double totalPagadoPersona(String personaId) {
+    return ThirdPartyExpenseCalculator.totalPagadoPorPersona(gastosPorPersona(personaId));
+  }
+
+  double totalPendientePersona(String personaId) {
+    return ThirdPartyExpenseCalculator.totalPendientePorPersona(gastosPorPersona(personaId));
+  }
+
+  Future<void> guardarPersona({
+    String? id,
+    required String nombre,
+    required String apellido,
+    String? email,
+  }) async {
+    final emailNormalizado = (email ?? '').trim();
+    final persona = PersonaTercero(
+      id: id ?? _uuid.v4(),
+      nombre: nombre,
+      apellido: apellido,
+      email: emailNormalizado.isEmpty ? null : emailNormalizado,
+    );
+
+    await _personService.guardarPersona(persona);
+    final index = _personas.indexWhere((p) => p.id == persona.id);
+    if (index >= 0) {
+      _personas[index] = persona;
+    } else {
+      _personas.add(persona);
+      _personas.sort((a, b) => a.nombreCompleto.compareTo(b.nombreCompleto));
+    }
+    notifyListeners();
+  }
+
+  Future<void> eliminarPersona(PersonaTercero persona, {bool eliminarGastos = false}) async {
+    await _personService.eliminarPersona(persona.id);
+    _personas.removeWhere((p) => p.id == persona.id);
+
+    if (eliminarGastos) {
+      final asociados = _gastos.where((gasto) => gasto.personaId == persona.id).toList();
+      for (final gasto in asociados) {
+        await _expenseService.eliminarGasto(gasto.id);
+        _gastos.remove(gasto);
+      }
+    } else {
+      _gastos.removeWhere((gasto) => gasto.personaId == persona.id);
+    }
+    notifyListeners();
+  }
+
+  Future<void> registrarGasto({
+    String? id,
+    required String personaId,
+    required double montoTotal,
+    required int cantidadCuotas,
+    required DateTime fechaPrimerVencimiento,
+    double? montoPorCuota,
+  }) async {
+    final totalNormalizado = double.parse(montoTotal.toStringAsFixed(2));
+
+    final cuotas = ThirdPartyExpenseCalculator.generarCuotas(
+      montoTotal: totalNormalizado,
+      cantidadCuotas: cantidadCuotas,
+      fechaPrimerVencimiento: fechaPrimerVencimiento,
+      montoPorCuota: montoPorCuota,
+    );
+
+    final gasto = GastoTercero(
+      id: id ?? _uuid.v4(),
+      personaId: personaId,
+      montoTotal: totalNormalizado,
+      cantidadCuotas: cantidadCuotas,
+      fechaPrimerVencimiento: fechaPrimerVencimiento,
+      cuotas: cuotas,
+    );
+
+    await _expenseService.guardarGasto(gasto);
+    final index = _gastos.indexWhere((element) => element.id == gasto.id);
+    if (index >= 0) {
+      _gastos[index] = gasto;
+    } else {
+      _gastos.add(gasto);
+    }
+    _gastos.sort((a, b) => a.fechaPrimerVencimiento.compareTo(b.fechaPrimerVencimiento));
+    notifyListeners();
+  }
+
+  Future<void> eliminarGasto(String gastoId) async {
+    await _expenseService.eliminarGasto(gastoId);
+    _gastos.removeWhere((gasto) => gasto.id == gastoId);
+    notifyListeners();
+  }
+
+  Future<void> marcarCuota(String gastoId, String cuotaId, bool pagada) async {
+    final gasto = _gastos.firstWhere((element) => element.id == gastoId);
+    final cuota = gasto.cuotas.firstWhere((element) => element.id == cuotaId);
+    cuota.estado = pagada ? CuotaEstado.pagada : CuotaEstado.pendiente;
+    await gasto.save();
+    notifyListeners();
+  }
+
+  Future<Map<String, dynamic>> generarReportePdf() async {
+    final mapa = <String, List<GastoTercero>>{};
+    for (final persona in _personas) {
+      mapa[persona.id] = gastosPorPersona(persona.id);
+    }
+    final bytes = await _pdfService.buildResumenPdf(personas: _personas, gastosPorPersona: mapa);
+    final archivo = await _pdfService.guardarPdf(bytes);
+    return {'bytes': bytes, 'file': archivo};
+  }
+
+  Future<void> compartirReporte(File archivo) async {
+    await _pdfService.compartirPdf(archivo);
+  }
+}

--- a/lib/services/third_party_expense_calculator.dart
+++ b/lib/services/third_party_expense_calculator.dart
@@ -1,0 +1,81 @@
+import 'dart:math';
+
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/cuota_terceros.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+
+class ThirdPartyExpenseCalculator {
+  static List<CuotaTercero> generarCuotas({
+    required double montoTotal,
+    required int cantidadCuotas,
+    required DateTime fechaPrimerVencimiento,
+    double? montoPorCuota,
+  }) {
+    if (cantidadCuotas <= 0) {
+      throw ArgumentError('La cantidad de cuotas debe ser mayor a cero');
+    }
+
+    final montos = _calcularMontosCuotas(
+      montoTotal: montoTotal,
+      cantidadCuotas: cantidadCuotas,
+      montoPorCuota: montoPorCuota,
+    );
+
+    return List<CuotaTercero>.generate(cantidadCuotas, (index) {
+      final fecha = _calcularFechaCuota(fechaPrimerVencimiento, index);
+      return CuotaTercero(
+        id: '${fecha.millisecondsSinceEpoch}-$index',
+        monto: montos[index],
+        fechaVencimiento: fecha,
+        estado: CuotaEstado.pendiente,
+      );
+    });
+  }
+
+  static double totalAdeudadoPorPersona(
+    List<GastoTercero> gastos,
+  ) {
+    return gastos.fold<double>(0, (suma, gasto) => suma + gasto.totalAdeudado);
+  }
+
+  static double totalPagadoPorPersona(List<GastoTercero> gastos) {
+    return gastos.fold<double>(0, (suma, gasto) => suma + gasto.totalPagado);
+  }
+
+  static double totalPendientePorPersona(List<GastoTercero> gastos) {
+    return gastos.fold<double>(0, (suma, gasto) => suma + gasto.totalPendiente);
+  }
+
+  static List<double> _calcularMontosCuotas({
+    required double montoTotal,
+    required int cantidadCuotas,
+    double? montoPorCuota,
+  }) {
+    final totalRedondeado = _redondear(montoTotal);
+    if (montoPorCuota != null) {
+      final totalCalculado = _redondear(montoPorCuota * cantidadCuotas);
+      if ((totalCalculado - totalRedondeado).abs() > 0.01) {
+        throw ArgumentError(
+          'El total informado no coincide con el calculado a partir del monto por cuota.',
+        );
+      }
+    }
+
+    final cuotaBase = montoPorCuota ?? (totalRedondeado / cantidadCuotas);
+    final cuotaRedondeada = _redondear(cuotaBase);
+
+    final montos = List<double>.filled(cantidadCuotas, cuotaRedondeada);
+    final sumaPrevia = _redondear(cuotaRedondeada * (cantidadCuotas - 1));
+    montos[cantidadCuotas - 1] = _redondear(totalRedondeado - sumaPrevia);
+    return montos;
+  }
+
+  static DateTime _calcularFechaCuota(DateTime fechaInicial, int index) {
+    final fechaBase = DateTime(fechaInicial.year, fechaInicial.month + index, 1);
+    final ultimoDiaMes = DateTime(fechaBase.year, fechaBase.month + 1, 0).day;
+    final dia = min(fechaInicial.day, ultimoDiaMes);
+    return DateTime(fechaBase.year, fechaBase.month, dia);
+  }
+
+  static double _redondear(double valor) => double.parse(valor.toStringAsFixed(2));
+}

--- a/lib/services/third_party_expense_service.dart
+++ b/lib/services/third_party_expense_service.dart
@@ -1,0 +1,34 @@
+import 'package:hive/hive.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+
+class ThirdPartyExpenseService {
+  static const String boxName = 'gastosTercerosBox';
+
+  Box<GastoTercero> get _box => Hive.box<GastoTercero>(boxName);
+
+  List<GastoTercero> obtenerGastos() {
+    final gastos = _box.values.toList();
+    gastos.sort((a, b) => a.fechaPrimerVencimiento.compareTo(b.fechaPrimerVencimiento));
+    return gastos;
+  }
+
+  List<GastoTercero> obtenerPorPersona(String personaId) {
+    return obtenerGastos().where((gasto) => gasto.personaId == personaId).toList();
+  }
+
+  Future<void> guardarGasto(GastoTercero gasto) async {
+    await _box.put(gasto.id, gasto);
+  }
+
+  Future<void> eliminarGasto(String gastoId) async {
+    await _box.delete(gastoId);
+  }
+
+  Future<void> eliminarGastosDePersona(PersonaTercero persona) async {
+    final gastos = obtenerPorPersona(persona.id);
+    for (final gasto in gastos) {
+      await _box.delete(gasto.id);
+    }
+  }
+}

--- a/lib/services/third_party_pdf_service.dart
+++ b/lib/services/third_party_pdf_service.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:share_plus/share_plus.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/services/third_party_expense_calculator.dart';
+
+class ThirdPartyPdfService {
+  Future<Uint8List> buildResumenPdf({
+    required List<PersonaTercero> personas,
+    required Map<String, List<GastoTercero>> gastosPorPersona,
+  }) async {
+    final pdf = pw.Document();
+    final date = DateTime.now();
+
+    pdf.addPage(
+      pw.MultiPage(
+        pageFormat: PdfPageFormat.a4,
+        build: (context) {
+          return [
+            pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                pw.Text(
+                  'Resumen de deudas por persona',
+                  style: pw.TextStyle(fontSize: 22, fontWeight: pw.FontWeight.bold),
+                ),
+                pw.SizedBox(height: 4),
+                pw.Text('Generado el ${date.toLocal()}'),
+                pw.SizedBox(height: 16),
+                ...personas.map((persona) {
+                  final gastos = gastosPorPersona[persona.id] ?? <GastoTercero>[];
+                  final totalAdeudado = ThirdPartyExpenseCalculator.totalAdeudadoPorPersona(gastos);
+                  final totalPagado = ThirdPartyExpenseCalculator.totalPagadoPorPersona(gastos);
+                  final totalPendiente = ThirdPartyExpenseCalculator.totalPendientePorPersona(gastos);
+
+                  return pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    children: [
+                      pw.Text(
+                        persona.nombreCompleto,
+                        style: pw.TextStyle(fontSize: 16, fontWeight: pw.FontWeight.bold),
+                      ),
+                      if (persona.email != null && persona.email!.isNotEmpty)
+                        pw.Text('Email: ${persona.email!}'),
+                      pw.SizedBox(height: 8),
+                      pw.Text('Total adeudado: ${totalAdeudado.toStringAsFixed(2)} ARS'),
+                      pw.Text('Total pagado: ${totalPagado.toStringAsFixed(2)} ARS'),
+                      pw.Text('Total pendiente: ${totalPendiente.toStringAsFixed(2)} ARS'),
+                      pw.SizedBox(height: 6),
+                      if (gastos.isEmpty)
+                        pw.Text('Sin gastos registrados.', style: const pw.TextStyle(fontStyle: pw.FontStyle.italic))
+                      else
+                        ...gastos.expand((gasto) {
+                          return [
+                            pw.Text(
+                              'Gasto: ${gasto.montoTotal.toStringAsFixed(2)} ARS - ${gasto.cantidadCuotas} cuotas',
+                              style: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+                            ),
+                            pw.Column(
+                              children: gasto.cuotas.asMap().entries.map((entry) {
+                                final index = entry.key + 1;
+                                final cuota = entry.value;
+                                final estado = cuota.estado == CuotaEstado.pagada ? 'Pagada' : 'Pendiente';
+                                final vencida = cuota.estaVencida ? ' (Vencida)' : '';
+                                final fecha = cuota.fechaVencimiento.toLocal();
+                                final fechaTexto =
+                                    '${fecha.day.toString().padLeft(2, '0')}/${fecha.month.toString().padLeft(2, '0')}/${fecha.year}';
+                                return pw.Padding(
+                                  padding: const pw.EdgeInsets.symmetric(vertical: 2),
+                                  child: pw.Text(
+                                    'Cuota $index: ${cuota.monto.toStringAsFixed(2)} ARS - '
+                                    'Vence $fechaTexto - $estado$vencida',
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                            pw.SizedBox(height: 8),
+                          ];
+                        }),
+                      pw.Divider(),
+                      pw.SizedBox(height: 12),
+                    ],
+                  );
+                }).toList(),
+              ],
+            ),
+          ];
+        },
+      ),
+    );
+
+    return pdf.save();
+  }
+
+  Future<File> guardarPdf(Uint8List bytes, {String? nombreArchivo}) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final fileName = nombreArchivo ?? 'reporte_gastos_terceros_$timestamp.pdf';
+    final archivo = File('${directory.path}/$fileName');
+    await archivo.writeAsBytes(bytes, flush: true);
+    return archivo;
+  }
+
+  Future<void> compartirPdf(File archivo) async {
+    await Share.shareXFiles([XFile(archivo.path)]);
+  }
+}

--- a/lib/services/third_party_person_service.dart
+++ b/lib/services/third_party_person_service.dart
@@ -1,0 +1,22 @@
+import 'package:hive/hive.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+
+class ThirdPartyPersonService {
+  static const String boxName = 'personasTercerosBox';
+
+  Box<PersonaTercero> get _box => Hive.box<PersonaTercero>(boxName);
+
+  List<PersonaTercero> obtenerPersonas() {
+    final personas = _box.values.toList();
+    personas.sort((a, b) => a.nombreCompleto.compareTo(b.nombreCompleto));
+    return personas;
+  }
+
+  Future<void> guardarPersona(PersonaTercero persona) async {
+    await _box.put(persona.id, persona);
+  }
+
+  Future<void> eliminarPersona(String personaId) async {
+    await _box.delete(personaId);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,9 @@ dependencies:
   month_picker_dialog: ^6.2.1
   fl_chart: ^0.63.0
   timezone: ^0.9.2
+  provider: ^6.1.2
+  pdf: ^3.11.0
+  share_plus: ^10.1.1
   # firebase_core: ^2.24.2
   # firebase_auth: 4.16.0
   # firebase_database: ^10.4.5

--- a/test/third_party/third_party_expense_calculator_test.dart
+++ b/test/third_party/third_party_expense_calculator_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/cuota_terceros.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/services/third_party_expense_calculator.dart';
+
+void main() {
+  group('ThirdPartyExpenseCalculator', () {
+    test('genera cuotas con vencimientos mensuales consistentes', () {
+      final fechaInicial = DateTime(2024, 1, 31);
+      final cuotas = ThirdPartyExpenseCalculator.generarCuotas(
+        montoTotal: 3000,
+        cantidadCuotas: 3,
+        fechaPrimerVencimiento: fechaInicial,
+      );
+
+      expect(cuotas, hasLength(3));
+      expect(cuotas.first.fechaVencimiento.day, equals(31));
+      expect(cuotas[1].fechaVencimiento.day, equals(29)); // febrero bisiesto
+      expect(cuotas[2].fechaVencimiento.day, equals(31));
+      final total = cuotas.fold<double>(0, (sum, cuota) => sum + cuota.monto);
+      expect(total.toStringAsFixed(2), equals('3000.00'));
+    });
+
+    test('calcula correctamente los totales por persona', () {
+      final gasto = GastoTercero(
+        id: '1',
+        personaId: 'persona',
+        montoTotal: 600,
+        cantidadCuotas: 3,
+        fechaPrimerVencimiento: DateTime(2024, 1, 10),
+        cuotas: [
+          CuotaTercero(
+            id: 'c1',
+            monto: 200,
+            fechaVencimiento: DateTime(2024, 1, 10),
+            estado: CuotaEstado.pagada,
+          ),
+          CuotaTercero(
+            id: 'c2',
+            monto: 200,
+            fechaVencimiento: DateTime(2024, 2, 10),
+            estado: CuotaEstado.pendiente,
+          ),
+          CuotaTercero(
+            id: 'c3',
+            monto: 200,
+            fechaVencimiento: DateTime(2024, 3, 10),
+            estado: CuotaEstado.pendiente,
+          ),
+        ],
+      );
+
+      final gastos = [gasto];
+
+      final totalAdeudado = ThirdPartyExpenseCalculator.totalAdeudadoPorPersona(gastos);
+      final totalPagado = ThirdPartyExpenseCalculator.totalPagadoPorPersona(gastos);
+      final totalPendiente = ThirdPartyExpenseCalculator.totalPendientePorPersona(gastos);
+
+      expect(totalAdeudado, equals(600));
+      expect(totalPagado, equals(200));
+      expect(totalPendiente, equals(400));
+    });
+  });
+}

--- a/test/third_party/third_party_pdf_service_test.dart
+++ b/test/third_party/third_party_pdf_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:test/test.dart';
+import 'package:tubilletera/model/cuota_estado.dart';
+import 'package:tubilletera/model/cuota_terceros.dart';
+import 'package:tubilletera/model/gasto_terceros.dart';
+import 'package:tubilletera/model/persona_terceros.dart';
+import 'package:tubilletera/services/third_party_pdf_service.dart';
+
+void main() {
+  test('genera un PDF no vacío con el resumen de personas', () async {
+    final servicio = ThirdPartyPdfService();
+    final persona = PersonaTercero(id: '1', nombre: 'Ana', apellido: 'Pérez', email: 'ana@test.com');
+    final gasto = GastoTercero(
+      id: 'g1',
+      personaId: '1',
+      montoTotal: 500,
+      cantidadCuotas: 2,
+      fechaPrimerVencimiento: DateTime(2024, 1, 10),
+      cuotas: [
+        CuotaTercero(
+          id: 'c1',
+          monto: 250,
+          fechaVencimiento: DateTime(2024, 1, 10),
+          estado: CuotaEstado.pagada,
+        ),
+        CuotaTercero(
+          id: 'c2',
+          monto: 250,
+          fechaVencimiento: DateTime(2024, 2, 10),
+          estado: CuotaEstado.pendiente,
+        ),
+      ],
+    );
+
+    final bytes = await servicio.buildResumenPdf(
+      personas: [persona],
+      gastosPorPersona: {
+        '1': [gasto],
+      },
+    );
+
+    expect(bytes, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add Hive-backed models for personas, gastos y cuotas de terceros junto con servicios de persistencia dedicados
- crear provider y vistas completas para gestionar personas, registrar gastos en cuotas, controlar pagos y exportar reportes PDF compartibles
- incorporar pruebas unitarias para la generación de cuotas, cálculo de totales y creación del PDF de resumen

## Testing
- Unable to run `flutter test` *(Flutter SDK no disponible en el entorno de ejecución)*

------
https://chatgpt.com/codex/tasks/task_e_68cacfc04f7c8332ada0cae86cbc1420